### PR TITLE
Session Notifications for working with Stripe Session Options

### DIFF
--- a/Notifications/OnProviderSessionOptionsAfterFullyCreated.cs
+++ b/Notifications/OnProviderSessionOptionsAfterFullyCreated.cs
@@ -1,0 +1,18 @@
+﻿using Stripe.Checkout;
+using Umbraco.Cms.Core.Notifications;
+
+namespace UmbCheckout.Stripe.Notifications
+{
+    /// <summary>
+    ///     Notification which is triggered just after the session options have been fully created with all options
+    /// </summary>
+    public class OnProviderSessionOptionsAfterFullyCreated : INotification
+    {
+        public SessionCreateOptions Options { get; set; }
+
+        public OnProviderSessionOptionsAfterFullyCreated(SessionCreateOptions options)
+        {
+            Options = options;
+        }
+    }
+}

--- a/Notifications/OnProviderSessionOptionsAfterInitiallyCreated.cs
+++ b/Notifications/OnProviderSessionOptionsAfterInitiallyCreated.cs
@@ -1,0 +1,18 @@
+﻿using Stripe.Checkout;
+using Umbraco.Cms.Core.Notifications;
+
+namespace UmbCheckout.Stripe.Notifications
+{
+    /// <summary>
+    ///     Notification which is triggered just after the initial session options are created
+    /// </summary>
+    public class OnProviderSessionOptionsAfterInitiallyCreated : INotification
+    {
+        public SessionCreateOptions Options { get; set; }
+
+        public OnProviderSessionOptionsAfterInitiallyCreated(SessionCreateOptions options)
+        {
+            Options = options;
+        }
+    }
+}

--- a/Notifications/OnProviderSessionOptionsLineItemAddedBefore.cs
+++ b/Notifications/OnProviderSessionOptionsLineItemAddedBefore.cs
@@ -1,0 +1,19 @@
+﻿using Stripe.Checkout;
+using Umbraco.Cms.Core.Notifications;
+
+namespace UmbCheckout.Stripe.Notifications
+{
+    /// <summary>
+    ///     Notification which is triggered just before a stripe line item is added to the
+    ///     line item collection that is sent to Stripe
+    /// </summary>
+    public class OnProviderSessionOptionsLineItemAddedBefore : INotification
+    {
+        public SessionLineItemOptions LineItem { get; set; }
+
+        public OnProviderSessionOptionsLineItemAddedBefore(SessionLineItemOptions lineItem)
+        {
+            LineItem = lineItem;
+        }
+    }
+}


### PR DESCRIPTION
These notifications allow for customization of session options before sending the finalized session options to the provider