### PR TITLE
Issue #93 allow passing of options of to Get method of Stripe Session Service

### DIFF
--- a/Interfaces/IStripeSessionService.cs
+++ b/Interfaces/IStripeSessionService.cs
@@ -1,5 +1,6 @@
 ﻿using Stripe.Checkout;
 using UmbCheckout.Shared.Models;
+using UmbCheckout.Stripe.Models;
 
 namespace UmbCheckout.Stripe.Interfaces
 {
@@ -12,8 +13,9 @@ namespace UmbCheckout.Stripe.Interfaces
         /// Gets a Stripe Session
         /// </summary>
         /// <param name="id">Id of the Stripe Session</param>
+        /// <param name="options">Optional Get Options</param>
         /// <returns>The Stripe Session</returns>
-        Session GetSession(string id);
+        Session GetSession(string id, UmbCheckoutSessionGetOptions? options = null);
 
         /// <summary>
         /// Gets a Stripe Session asynchronously

--- a/Models/UmbCheckoutSessionGetOptions.cs
+++ b/Models/UmbCheckoutSessionGetOptions.cs
@@ -1,0 +1,24 @@
+﻿using Stripe.Checkout;
+using UmbCheckout.Stripe.Interfaces;
+
+namespace UmbCheckout.Stripe.Models;
+
+/// <summary>
+/// Wrapper for the <see cref="SessionGetOptions"/> used to specify options when calling <see cref="IStripeSessionService.GetSession"/>>
+/// </summary>
+public class UmbCheckoutSessionGetOptions
+{
+    /// <summary>
+    /// List of Property names in the <see cref="Session"/> to be expanded when calling <see cref="IStripeSessionService.GetSession"/>
+    /// Reference https://docs.stripe.com/api/expanding_objects
+    /// </summary>
+    public List<string>? Expand { get; set; }
+
+    public SessionGetOptions ToSessionGetOptions()
+    {
+        return new SessionGetOptions
+        {
+            Expand = Expand
+        };
+    }
+}

--- a/Services/StripeSessionService.cs
+++ b/Services/StripeSessionService.cs
@@ -48,7 +48,7 @@ namespace UmbCheckout.Stripe.Services
         }
 
         /// <inheritdoc />
-        public Session GetSession(string id)
+        public Session GetSession(string id, UmbCheckoutSessionGetOptions? options = null)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace UmbCheckout.Stripe.Services
                 var stripeClient = new StripeClient(apiKey);
 
                 var service = new SessionService(stripeClient);
-                var session = service.Get(id);
+                var session = service.Get(id, options?.ToSessionGetOptions());
 
                 scope.Notifications.Publish(new OnProviderGetSessionNotification(id));
 


### PR DESCRIPTION
Modify GetSession to take optional UmbCheckoutSessionGetOptions argument. UmbCheckoutSessionGetOptions is a wrapper for Stripe SessionGetOptions to allow passing of other properties in future.  For now just a list of expandable properties are included