### PR TITLE
#7 Implement default shipping rate calculation which can be overriden

### DIFF
--- a/Composers/RegisterServicesComposer.cs
+++ b/Composers/RegisterServicesComposer.cs
@@ -17,6 +17,7 @@ namespace UmbCheckout.Stripe.Composers
             builder.Services.AddTransient<IStripeSessionService, StripeSessionService>();
             builder.Services.AddTransient<IStripeShippingRateDatabaseService, StripeShippingRateDatabaseService>();
             builder.Services.AddTransient<IStripeShippingRateApiService, StripeShippingRateApiService>();
+            builder.Services.AddTransient<IStripeShippingOptionsService, StripeDefaultShippingOptionsService>();
             builder.Services.AddTransient<IStripeSettingsService, StripeSettingsService>();
 
 #if NET8_0_OR_GREATER

--- a/Interfaces/IStripeShippingOptionsService.cs
+++ b/Interfaces/IStripeShippingOptionsService.cs
@@ -1,0 +1,13 @@
+﻿using Stripe.Checkout;
+using UmbCheckout.Shared.Models;
+
+namespace UmbCheckout.Stripe.Interfaces;
+
+
+/// <summary>
+/// Interface for calculating the shipping rates to be applied to a basket. <see cref="IStripeSessionService.CreateSession"/> 
+/// </summary>
+public interface IStripeShippingOptionsService
+{
+    Task<List<SessionShippingOptionOptions>> GetShippingOptions(Basket basket);
+}

--- a/Services/StripeDefaultShippingOptionsService.cs
+++ b/Services/StripeDefaultShippingOptionsService.cs
@@ -1,0 +1,34 @@
+﻿using Stripe.Checkout;
+using UmbCheckout.Shared.Models;
+using UmbCheckout.Stripe.Interfaces;
+
+namespace UmbCheckout.Stripe.Services;
+
+/// <summary>
+/// Default implementation of the <see cref="IStripeShippingOptionsService" />
+/// </summary>
+public class StripeDefaultShippingOptionsService : IStripeShippingOptionsService
+{
+    private readonly IStripeShippingRateDatabaseService _stripeDatabaseService;
+
+    public StripeDefaultShippingOptionsService(IStripeShippingRateDatabaseService stripeDatabaseService)
+    {
+        _stripeDatabaseService = stripeDatabaseService;
+    }
+
+    public async Task<List<SessionShippingOptionOptions>> GetShippingOptions(Basket basket)
+    {
+        var shippingRates = await _stripeDatabaseService.GetShippingRates();
+        var shippingRatesList = shippingRates.ToList();
+
+        if (shippingRatesList.Any())
+        {
+            var shippingRateOptions = shippingRatesList.Select(shippingRate =>
+                new SessionShippingOptionOptions { ShippingRate = shippingRate.Value }).ToList();
+
+            return shippingRateOptions;
+        }
+
+        return new List<SessionShippingOptionOptions>();
+    }
+}


### PR DESCRIPTION
This implementation just replicates the default shipping rate calculation.
In a solution consuming UmbCheckout add an entry to a composer to replace the default shipping rate calculation with a custom one.  

`        builder.Services.AddTransient<IStripeShippingOptionsService, CustomShippingRates>();`

The basket is passed into the method so the custom calculation can create a SessionShippingOptionOptions object for each shipping rate you want displayed in the checkout page with the cost calculated based on the basket contents.
